### PR TITLE
Update to support RN 29+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.15.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.anjlab.android.iab.v3:library:1.0.+'
 }

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -26,14 +26,12 @@ import java.util.Map;
 public class InAppBillingBridge extends ReactContextBaseJavaModule implements ActivityEventListener, BillingProcessor.IBillingHandler {
     ReactApplicationContext _reactContext;
     String LICENSE_KEY = null;
-    final Activity _activity;
     BillingProcessor bp;
 
     public InAppBillingBridge(ReactApplicationContext reactContext, String licenseKey) {
         super(reactContext);
         _reactContext = reactContext;
         LICENSE_KEY = licenseKey;
-        _activity = getCurrentActivity();
 
         reactContext.addActivityEventListener(this);
     }
@@ -45,7 +43,6 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
                 .getResources()
                 .getIdentifier("RNB_GOOGLE_PLAY_LICENSE_KEY", "string", _reactContext.getPackageName());
         LICENSE_KEY = _reactContext.getString(keyResourceId);
-        _activity = getCurrentActivity();
 
         reactContext.addActivityEventListener(this);
     }
@@ -124,7 +121,7 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     public void purchase(final String productId, final String developerPayload, final Promise promise){
         if (bp != null) {
             if (putPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, promise)) {
-                boolean purchaseProcessStarted = bp.purchase(_activity, productId, developerPayload);
+                boolean purchaseProcessStarted = bp.purchase(getCurrentActivity(), productId, developerPayload);
                 if (!purchaseProcessStarted)
                     rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start purchase process.");
             } else {
@@ -156,7 +153,7 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     public void subscribe(final String productId, final String developerPayload, final Promise promise){
         if (bp != null) {
             if (putPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, promise)) {
-                boolean subscribeProcessStarted = bp.subscribe(_activity, productId, developerPayload);
+                boolean subscribeProcessStarted = bp.subscribe(getCurrentActivity(), productId, developerPayload);
                 if (!subscribeProcessStarted)
                     rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start subscribe process.");
             } else {

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -29,23 +29,23 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     final Activity _activity;
     BillingProcessor bp;
 
-    public InAppBillingBridge(ReactApplicationContext reactContext, String licenseKey, Activity activity) {
+    public InAppBillingBridge(ReactApplicationContext reactContext, String licenseKey) {
         super(reactContext);
         _reactContext = reactContext;
         LICENSE_KEY = licenseKey;
-        _activity = activity;
+        _activity = getCurrentActivity();
 
         reactContext.addActivityEventListener(this);
     }
 
-    public InAppBillingBridge(ReactApplicationContext reactContext, Activity activity) {
+    public InAppBillingBridge(ReactApplicationContext reactContext) {
         super(reactContext);
         _reactContext = reactContext;
         int keyResourceId = _reactContext
                 .getResources()
                 .getIdentifier("RNB_GOOGLE_PLAY_LICENSE_KEY", "string", _reactContext.getPackageName());
         LICENSE_KEY = _reactContext.getString(keyResourceId);
-        _activity = activity;
+        _activity = getCurrentActivity();
 
         reactContext.addActivityEventListener(this);
     }

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridgePackage.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridgePackage.java
@@ -17,6 +17,9 @@ public class InAppBillingBridgePackage implements ReactPackage {
         _licenseKeySetInConstructor = true;
     }
 
+    public InAppBillingBridgePackage() {
+    }
+
     private String _licenseKey;
     private Boolean _licenseKeySetInConstructor = false;
 

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridgePackage.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridgePackage.java
@@ -1,7 +1,5 @@
 package com.idehub.Billing;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -14,28 +12,22 @@ import java.util.List;
 
 public class InAppBillingBridgePackage implements ReactPackage {
 
-    public InAppBillingBridgePackage(String licenseKey, Activity activity) {
+    public InAppBillingBridgePackage(String licenseKey) {
         _licenseKey = licenseKey;
         _licenseKeySetInConstructor = true;
-        _activity = activity;
-    }
-
-    public InAppBillingBridgePackage(Activity activity) {
-        _activity = activity;
     }
 
     private String _licenseKey;
     private Boolean _licenseKeySetInConstructor = false;
-    private Activity _activity;
 
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
       		if (!_licenseKeySetInConstructor)
-              	modules.add(new InAppBillingBridge(reactContext, _activity));
+              	modules.add(new InAppBillingBridge(reactContext));
       		else
-                modules.add(new InAppBillingBridge(reactContext, _licenseKey, _activity));
+                modules.add(new InAppBillingBridge(reactContext, _licenseKey));
 
           return modules;
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/idehub/react-native-billing#readme",
   "rnpm": {
     "android": {
-      "packageInstance": "new InAppBillingBridgePackage(this)"
+      "packageInstance": "new InAppBillingBridgePackage()"
     }
   }
 }


### PR DESCRIPTION
In React Native release 0.29 a new application template was implemented. The change requires a different implementation for plugin users (updated in the Readme) and a different way of getting the activity inside the plugin (no more passing `this`).

This PR implements the changes. I tested the changes in my RN 29 app and it works fine. The changes should be backwards compatible.
