### PR TITLE
Fix Null Object Reference when testing static response purchase

### DIFF
--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -341,7 +341,7 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
         map.putString("productId", purchaseData.productId);
         map.putString("orderId", purchaseData.orderId);
         map.putString("purchaseToken", purchaseData.purchaseToken);
-        map.putString("purchaseTime", purchaseData.purchaseTime.toString());
+        map.putString("purchaseTime", purchaseData.purchaseTime != null ? purchaseData.purchaseTime.toString() : "");
         map.putString("purchaseState", purchaseData.purchaseState.toString());
 
         if (purchaseData.developerPayload != null)


### PR DESCRIPTION
When testing a static response purchase, the following error is returned:
`Failure on purchase or subscribe callback: Attempt to invoke virtual method 'java.lang.String java.util.Date.toString()' on a null object reference(…)`

Catching the null date and returning an empty string allows to test the purchase with a static response properly.