### PR TITLE
add updateSubscription method

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,26 @@ InAppBilling.subscribe('your.inapp.productid')
 InAppBilling.isSubscribed('your.inapp.productid').then(...);
 ```
 
+### updateSubscription(oldProductIds, productId)
+##### Parameter(s)
+* **oldProductIds (required)**: Array of String
+* **productId (required)**: String
+
+##### Returns:
+* **transactionDetails:** Object:
+  * **productId:** String
+  * **orderId:** String
+  * **purchaseToken:** String
+  * **purchaseTime:** String
+  * **purchaseState:** String ("PurchasedSuccessfully", "Canceled", "Refunded", "SubscriptionExpired")
+  * **receiptSignature:** String
+  * **receiptData:** String
+  * **developerPayload:** String
+
+```javascript
+InAppBilling.updateSubscription(['subscription.p1m', 'subscription.p3m'], 'subscription.p12m').then(...)
+```
+
 ### isPurchased(productId)
 ##### Parameter(s)
 * **productId (required):** String

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -165,6 +165,22 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void updateSubscription(final List<String> oldProductIds, final String productId, final Promise promise){
+        if (bp != null) {
+            if (putPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, promise)) {
+                boolean updateProcessStarted = bp.updateSubscription(getCurrentActivity(), oldProductIds, productId);
+                if (!updateProcessStarted) {
+                    rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start updateSubscription process.");
+                }
+          } else {
+              promise.reject("EUNSPECIFIED", "Previous subscribe or purchase operation is not resolved.");
+          }
+        } else {
+            promise.reject("EUNSPECIFIED", "Channel is not opened. Call open() on InAppBilling.");
+        }
+    }
+
+    @ReactMethod
     public void isSubscribed(final String productId, final Promise promise){
         if (bp != null) {
             boolean subscribed = bp.isSubscribed(productId);

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -167,18 +167,19 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     @ReactMethod
     public void updateSubscription(final ReadableArray oldProductIds, final String productId, final Promise promise){
         if (bp != null) {
-            ArrayList<String> oldProductIdList = new ArrayList<>();
-            for (int i = 0; i < oldProductIds.size(); i++) {
-                oldProductIdList.add(oldProductIds.getString(i));
-            }
             if (putPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, promise)) {
-                boolean updateProcessStarted = bp.updateSubscription(getCurrentActivity(), oldProductIdList, productId);
-                if (!updateProcessStarted) {
-                    rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start updateSubscription process.");
+                ArrayList<String> oldProductIdList = new ArrayList<>();
+                for (int i = 0; i < oldProductIds.size(); i++) {
+                    oldProductIdList.add(oldProductIds.getString(i));
                 }
-          } else {
-              promise.reject("EUNSPECIFIED", "Previous subscribe or purchase operation is not resolved.");
-          }
+
+                boolean updateProcessStarted = bp.updateSubscription(getCurrentActivity(), oldProductIdList, productId);
+
+                if (!updateProcessStarted)
+                    rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start updateSubscription process.");
+            } else {
+                promise.reject("EUNSPECIFIED", "Previous subscribe or purchase operation is not resolved.");
+            }
         } else {
             promise.reject("EUNSPECIFIED", "Channel is not opened. Call open() on InAppBilling.");
         }

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -165,10 +165,14 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void updateSubscription(final List<String> oldProductIds, final String productId, final Promise promise){
+    public void updateSubscription(final ReadableArray oldProductIds, final String productId, final Promise promise){
         if (bp != null) {
+            ArrayList<String> oldProductIdList = new ArrayList<>();
+            for (int i = 0; i < oldProductIds.size(); i++) {
+                oldProductIdList.add(oldProductIds.getString(i));
+            }
             if (putPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, promise)) {
-                boolean updateProcessStarted = bp.updateSubscription(getCurrentActivity(), oldProductIds, productId);
+                boolean updateProcessStarted = bp.updateSubscription(getCurrentActivity(), oldProductIdList, productId);
                 if (!updateProcessStarted) {
                     rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "Could not start updateSubscription process.");
                 }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ class InAppBilling {
       return InAppBillingBridge.subscribe(productId, developerPayload);
     }
 
+    static updateSubscription(oldProductIds, productId) {
+      return InAppBillingBridge.updateSubscription(oldProductIds, productId)
+    }
+
     static isSubscribed(productId) {
       return InAppBillingBridge.isSubscribed(productId);
     }


### PR DESCRIPTION
Hi @cbrevik,

This PR adds support for the `getBuyIntentToReplaceSkus` method. I've tested it and observed the subscriptions being replaced, hence why it took me a few days as test subscriptions are renewed daily.

It reports correctly that a subscription has been purchased, however due to the app cache, the original products remain until the cache is cleared.

Closes https://github.com/idehub/react-native-billing/issues/40