### PR TITLE
add loadOwnedPurchasesFromGoogle() wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,3 +409,9 @@ InAppBilling.getSubscriptionTransactionDetails('your.inapp.productid')
   console.log(details)
 });
 ```
+
+### loadOwnedPurchasesFromGoogle()
+Refreshes the internal purchases & subscriptions status cache.
+```javascript
+InAppBilling.loadOwnedPurchasesFromGoogle().then(...);
+```

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -96,6 +96,16 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
         promise.resolve(true);
     }
 
+    @ReactMethod
+    public void loadOwnedPurchasesFromGoogle(final Promise promise){
+      if (bp != null) {
+          bp.loadOwnedPurchasesFromGoogle();
+          promise.resolve(true);
+      } else {
+          promise.reject("EUNSPECIFIED", "Channel is not opened. Call open() on InAppBilling.");
+      }
+    }
+
     @Override
     public void onProductPurchased(String productId, TransactionDetails details) {
         if (details != null && productId.equals(details.purchaseInfo.purchaseData.productId))

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ class InAppBilling {
       return InAppBillingBridge.close();
     }
 
+    static loadOwnedPurchasesFromGoogle() {
+        return InAppBillingBridge.loadOwnedPurchasesFromGoogle();
+    }
+
     static purchase(productId, developerPayload = null) {
       return InAppBillingBridge.purchase(productId, developerPayload);
     }


### PR DESCRIPTION
Hi,

I had the same troubles as described in #9 , and calling loadOwnedPurchasesFromGoogle() before getSubscriptionTransactionDetails() helped. Apart from the question if this method should always be run by open(), i think it is a necessary enhancement to the API, at least as long as anjlab's lib raises such issues.