### PR TITLE
README.md update: getProductDetails vs getSubscriptionDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ InAppBilling.listOwnedSubscriptions().then(...);
 ```
 
 ### getProductDetails(productId)
+**Important:** Use this to query managed products. Subscriptions require the use of `getSubscriptionDetails`.
 ##### Parameter(s)
 * **productId (required):** String
 


### PR DESCRIPTION
Clarified the difference between getProductDetails and getSubscriptionDetails

Reference #51 