### PR TITLE
Expose free trial and introductory price details for subscription skus

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,14 @@ InAppBilling.getProductDetailsArray(['your.inapp.productid', 'your.inapp.product
   * **currency:** String
   * **priceValue:**  Double
   * **priceText:** String
+  * **subscriptionPeriod** String
+  * **subscriptionFreeTrialPeriod** String - Only if product has a free trial period
+  * **haveTrialPeriod** Boolean
+  * **introductoryPriceValue** Double
+  * **introductoryPriceText** String - Only if product has a introductory price
+  * **introductoryPricePeriod** String - Only if product has a introductory price
+  * **haveIntroductoryPeriod** Boolean
+  * **introductoryPriceCycles** Number
 
 ```javascript
 InAppBilling.getSubscriptionDetails('your.inapp.productid').then(...);

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -311,6 +311,17 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
                             map.putString("currency", detail.currency);
                             map.putDouble("priceValue", detail.priceValue);
                             map.putString("priceText", detail.priceText);
+                            map.putString("subscriptionPeriod", detail.subscriptionPeriod);
+                            if (detail.subscriptionFreeTrialPeriod != null)
+                                map.putString("subscriptionFreeTrialPeriod", detail.subscriptionFreeTrialPeriod);
+                            map.putBoolean("haveTrialPeriod", detail.haveTrialPeriod);
+                            map.putDouble("introductoryPriceValue", detail.introductoryPriceValue);
+                            if (detail.introductoryPriceText != null)
+                                map.putString("introductoryPriceText", detail.introductoryPriceText);
+                            if (detail.introductoryPricePeriod != null)
+                                map.putString("introductoryPricePeriod", detail.introductoryPricePeriod);
+                            map.putBoolean("haveIntroductoryPeriod", detail.haveIntroductoryPeriod);
+                            map.putInt("introductoryPriceCycles", detail.introductoryPriceCycles);
                             arr.pushMap(map);
                         }
                     }


### PR DESCRIPTION
Underlying library already exposes these values see:

[android-inapp-billing-v3:SkuDetails.java#L86-L94](https://github.com/anjlab/android-inapp-billing-v3/blob/master/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java#L86-L94)

Documentation on what they mean here:

[Billing Details API Reference - getSkuDetails](https://developer.android.com/google/play/billing/billing_reference.html#getSkuDetails)