### PR TITLE
Make sure to call BillingProcessor::handleActivityResult()

### DIFF
--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -410,12 +410,7 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
 
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        if (requestCode != PromiseConstants.PURCHASE_FLOW_REQUEST_CODE) {
-            return;
-        }
-
-        int responseCode = data.getIntExtra(PromiseConstants.RESPONSE_CODE, PromiseConstants.BILLING_RESPONSE_RESULT_OK);
-        if (resultCode == Activity.RESULT_OK && responseCode == PromiseConstants.BILLING_RESPONSE_RESULT_OK) {
+        if (bp.handleActivityResult(requestCode, resultCode, data)) {
             resolvePromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, true);
         } else {
             rejectPromise(PromiseConstants.PURCHASE_OR_SUBSCRIBE, "An error has occured. Code " + requestCode);


### PR DESCRIPTION
I found that this library never calls BillingProcessor::handleActivityResult(). It seems calling this method is absolutely necessary, but I could not find anywhere in the codebase calling.

handleActivityResult() does important things such as calling onProductPurchased, reportBillingError(), write purchaseData to the cache, so not calling this is critical.

This PR fixed the following problems for me:
1. The first purchase() returns ```true```, but the second purchase returns transactionDetails
2. listOwnedProducts() is not up-to-date right after calling purchase()

I think there is a good chance I am misunderstanding something, in that case please let me know what I am doing wrong. At least it is true that I was having the issue 1&2.

 I am using ```react-native 0.52.0``` & ```react-native-billing: 2.5.0```