### PR TITLE
add support for isValidTransactionDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,24 @@ InAppBilling.isPurchased('your.inapp.productid').then(...);
 InAppBilling.isOneTimePurchaseSupported().then(...);
 ```
 
+### isValidTransactionDetails(productId)
+Validates if the transaction for the productId has a valid signature.
+
+##### Parameter(s)
+
+* **productId (required):** String
+
+##### Returns:
+
+* **isValid:** Boolean
+```javascript
+InAppBilling.isValidTransactionDetails("your.inapp.productid").then(
+  isValid => {
+    console.log(isValid);
+  }
+);
+```
+
 ### listOwnedProducts()
 
 ##### Returns:

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -229,6 +229,20 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void isValidTransactionDetails(final String productId, final Promise promise) {
+        if (bp != null) {
+            try {
+                TransactionDetails details = bp.getPurchaseTransactionDetails(productId);
+                promise.resolve(bp.isValidTransactionDetails(details));
+            } catch (Exception ex) {
+                promise.reject("EUNSPECIFIED", "Failed to validate transaction details: " + ex.getMessage());
+            }
+        } else {
+            promise.reject("EUNSPECIFIED", "Channel is not opened. Call open() on InAppBilling.");
+        }
+    }
+
+    @ReactMethod
     public void listOwnedProducts(final Promise promise){
         if (bp != null) {
             List<String> purchasedProductIds = bp.listOwnedProducts();

--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ class InAppBilling {
     return InAppBillingBridge.isOneTimePurchaseSupported();
   }
 
+  static isValidTransactionDetails(productId) {
+    return InAppBillingBridge.isValidTransactionDetails(productId);
+  }
+
   static listOwnedProducts() {
     return InAppBillingBridge.listOwnedProducts();
   }


### PR DESCRIPTION
Expose a call to isValidTransactionDetails so that a transaction can be checked if it has a valid transaction. Allows an additional client check to protect against purchases.