### PR TITLE
add support for isOneTimePurchaseSupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ InAppBilling.updateSubscription(['subscription.p1m', 'subscription.p3m'], 'subsc
 InAppBilling.isPurchased('your.inapp.productid').then(...);
 ```
 
+### isOneTimePurchaseSupported()
+
+##### Returns:
+
+* **oneTimePurchaseSupported:** Boolean
+
+```javascript
+InAppBilling.isOneTimePurchaseSupported().then(...);
+```
+
 ### listOwnedProducts()
 
 ##### Returns:

--- a/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
+++ b/android/src/main/java/com/idehub/Billing/InAppBillingBridge.java
@@ -219,6 +219,16 @@ public class InAppBillingBridge extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void isOneTimePurchaseSupported(final Promise promise){
+        if (bp != null) {
+            boolean oneTimePurchaseSupported = bp.isOneTimePurchaseSupported();
+            promise.resolve(oneTimePurchaseSupported);
+        } else {
+            promise.reject("EUNSPECIFIED", "Channel is not opened. Call open() on InAppBilling.");
+        }
+    }
+
+    @ReactMethod
     public void listOwnedProducts(final Promise promise){
         if (bp != null) {
             List<String> purchasedProductIds = bp.listOwnedProducts();

--- a/index.js
+++ b/index.js
@@ -40,6 +40,10 @@ class InAppBilling {
     return InAppBillingBridge.isPurchased(productId);
   }
 
+  static isOneTimePurchaseSupported() {
+    return InAppBillingBridge.isOneTimePurchaseSupported();
+  }
+
   static listOwnedProducts() {
     return InAppBillingBridge.listOwnedProducts();
   }


### PR DESCRIPTION
Expose the call so that the java bridge can check is one time purchase is supported. Allows the client to exit early if the android device does not support billing.