### PR TITLE
Replace dependencies types from compile to api, implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,6 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    compile "com.anjlab.android.iab.v3:library:${safeExtGet('anjlabIABVersion', '1.0.44')}"
+    api "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.anjlab.android.iab.v3:library:${safeExtGet('anjlabIABVersion', '1.0.44')}"
 }


### PR DESCRIPTION
Per Android studio logs:

> WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

This commit fixes this warning